### PR TITLE
Main

### DIFF
--- a/examples/Example2D_paper.jl
+++ b/examples/Example2D_paper.jl
@@ -86,7 +86,7 @@ for fni in ("meltfraction","dϕdT","density","heatcapacity","conductivity","radi
 end
 
 function update_dϕdT_Phi!(dϕdT, Phi_melt, Z)
-    for i in eachindex(Z)
+    Threads.@Threads for i in eachindex(Z)
         @inbounds if Z[i] < -15e3
             dϕdT[i] = 0.0
             Phi_melt[i] = 0.0
@@ -117,7 +117,7 @@ function Nonlinear_Diffusion_step!(Tnew, T,  T_K, T_it_old, Mat_tup, Phi_melt, P
 
         # Switch off latent heat & melting below a certain depth 
         if Num.deactivate_La_at_depth==true
-            @parallel (1:Nx,1:Nz) update_dϕdT_Phi!(dϕdT, Phi_melt, Z)
+            update_dϕdT_Phi!(dϕdT, Phi_melt, Z)
         end
 
         # Diffusion step:
@@ -201,7 +201,7 @@ end
     time, dike_inj, InjectVol, Time_vec,Melt_Time,Tav_magma_Time = 0.0, 0.0, 0.0,zeros(nt,1),zeros(nt,1),zeros(nt,1);
 
     if isdir(Num.SimName)==false mkdir(Num.SimName) end;    # create simulation directory if needed
-    for it = 1:100   # Time loop
+    for it = 1:nt   # Time loop
 
         # Add new dike every X years:
         if floor(time/Dikes.InjectionInterval)> dike_inj      
@@ -475,6 +475,6 @@ if 1==0
 end
 
 # Call the main code with the specified material parameters
-x,z,T, Time_vec,Melt_Time, Tracers, dike_poly = MainCode_2D(MatParam, Num, Dike_params); # start the main code
+@time x,z,T, Time_vec,Melt_Time, Tracers, dike_poly = MainCode_2D(MatParam, Num, Dike_params); # start the main code
 
 #plot(Time_vec/kyr, Melt_Time, xlabel="Time [kyrs]", ylabel="Fraction of crust that is molten", label=:none); png("Time_vs_Melt_Example2D") #Create plot


### PR DESCRIPTION
This PR adds some optimizations for the CPU version of `examples/Example_2D_paper.jl` and  complementary CUDA (powered via ParallelStencil.jl) script. Perfromance (512X512 grid, 100 iterations):

new cpu
```iterations 5.906241 seconds (10.21 M allocations: 742.317 MiB, 0.95% gc time)```

old cpu 
``` 11.066817 seconds (208.82 k allocations: 4.488 GiB, 1.08% gc time)```

cuda
```1.323841 seconds (264.43 k allocations: 488.701 MiB, 2.94% gc time, 1.79% compilation time)```
